### PR TITLE
Add dependency to Blizzard_ObjectTracker

### DIFF
--- a/SylingTracker.toc
+++ b/SylingTracker.toc
@@ -3,7 +3,7 @@
 ## Version: @project-version@
 ## Author: Skamer
 ## SavedVariables: SylingTrackerDB
-## Dependencies: PLoop, Scorpio, Scorpio.Widget
+## Dependencies: PLoop, Scorpio, Scorpio.Widget, Blizzard_ObjectTracker
 ## OptionalDeps: ViragDevTool
 # Embed libs
 embeds.xml


### PR DESCRIPTION
This resolves issue #6 partly.
Appareantly there is still an issue if you use the battlefield map (pvp).
But in the normal game world this doesn't cause the error anymore.

credit to Kurapica who told me of this solution in the WoWUIDev discord.