### PR TITLE
Adds toggle command again

### DIFF
--- a/SylingTracker.lua
+++ b/SylingTracker.lua
@@ -132,6 +132,11 @@ function HideCommand()
   _M:FireSystemEvent("SLT_HIDE_COMMAND")
 end
 
+__SlashCmd__ "slt" "toggle" "- toggle the Tracker and the Item Bar"
+function ToggleCommand()
+  _M:FireSystemEvent("SLT_TOGGLE_COMMAND")
+end
+
 __SlashCmd__ "slt" "log" "- set the log level"
 function SetLogLevel(info)
   local val = tonumber(info)


### PR DESCRIPTION
The command registration has accidentally been overwritten. This introduces the command again.