### PR TITLE
Fix some icons being upside down, use RectType for texcoords

### DIFF
--- a/Contents/Achievements/AchievementView.lua
+++ b/Contents/Achievements/AchievementView.lua
@@ -419,7 +419,7 @@ Style.UpdateSkin("Default", {
         Anchor("TOPLEFT", 5, -5, "Name", "BOTTOMLEFT")
       },
       Icon = {
-        texCoords = { top = 0.93, left = 0.07, bottom = 0.07, right = 0.93}
+        texCoords = RectType(0.07, 0.93, 0.07, 0.93)
       }
     },
 

--- a/Contents/Achievements/AchievementsContentView.lua
+++ b/Contents/Achievements/AchievementsContentView.lua
@@ -143,7 +143,7 @@ Style.UpdateSkin("Default", {
         backdropColor = { r = 0, g = 0, b = 0, a = 0},
         Icon = {
           file = [[Interface\ACHIEVEMENTFRAME\UI-ACHIEVEMENT-SHIELDS]],
-          texCoords = { left = 0, right = 64/128, top = 0, bottom = 64/128 }
+          texCoords = RectType(0, 64/128, 0, 64/128)
         }
       },
 

--- a/Contents/Keystone/KeystoneContentView.lua
+++ b/Contents/Keystone/KeystoneContentView.lua
@@ -559,7 +559,7 @@ Style.UpdateSkin("Default", {
 
     Icon = {
       setAllPoints = true,
-      texCoords = { top = 0.93, left = 0.07, bottom = 0.07, right = 0.93}
+      texCoords = RectType(0.07, 0.93, 0.07, 0.93)
     }
   },
 

--- a/Contents/Quests/QuestView.lua
+++ b/Contents/Quests/QuestView.lua
@@ -677,7 +677,7 @@ Style.UpdateSkin("Default", {
           },
 
           Icon = {
-            texCoords = { top = 0.93, left = 0.07, bottom = 0.07, right = 0.93}
+            texCoords = RectType(0.07, 0.93, 0.07, 0.93)
           }
         },
         Objectives = {

--- a/Contents/Tasks/TaskView.lua
+++ b/Contents/Tasks/TaskView.lua
@@ -461,7 +461,7 @@ Style.UpdateSkin("Default", {
           },
 
           Icon = {
-            texCoords = { top = 0.93, left = 0.07, bottom = 0.07, right = 0.93}
+            texCoords = RectType(0.07, 0.93, 0.07, 0.93)
           }
         },
 

--- a/UI/Arrow.lua
+++ b/UI/Arrow.lua
@@ -23,10 +23,10 @@ class "Arrow" (function(_ENV)
   }
 
   _ARROW_TEX_COORDS = {
-    ["RIGHT"] = { left = 0, right = 32/128, top = 0, bottom = 1 },
-    ["BOTTOM"] = { left = 32/128, right = 64/128, top = 0, bottom = 1 },
-    ["LEFT"] = { left = 64/128, right = 96/128, top = 0, bottom = 1 },
-    ["TOP"] = { left = 96/128, right = 1, top = 0, bottom = 1 }
+    ["RIGHT"] = RectType(0, 32/128, 0, 1),
+    ["BOTTOM"] = RectType(32/128, 64/128, 0, 1),
+    ["LEFT"] = RectType(64/128, 96/128, 0, 1),
+    ["TOP"] = RectType(96/128, 1, 0, 1)
   }
   -----------------------------------------------------------------------------
   --                               Handlers                                  --


### PR DESCRIPTION
Top and bottom texcoord values were switched in some cases resulting in flipped images.